### PR TITLE
Fix import guard to allow library usage

### DIFF
--- a/tests/test_import_guard.py
+++ b/tests/test_import_guard.py
@@ -1,0 +1,29 @@
+"""Tests that yesc can be imported as a library without triggering execution."""
+
+import sys
+
+
+def test_import_does_not_trigger_execution():
+    """Importing yesc.yesc should not call parse_args() or main().
+
+    Before the fix, importing yesc.yesc at module level calls
+    parser.parse_args() and main(args), which fails or runs unintended code.
+    After the fix, import should succeed silently.
+    """
+    # Remove yesc from sys.modules if previously imported, to test fresh import
+    for key in list(sys.modules):
+        if key == "yesc" or key.startswith("yesc."):
+            del sys.modules[key]
+
+    # This import should succeed without side effects
+    from yesc.yesc import main
+
+    assert callable(main)
+
+
+def test_parser_not_at_module_level():
+    """parser should only exist inside if __name__ == '__main__', not as a
+    module attribute accessible on import."""
+    from yesc import yesc as yesc_module
+
+    assert not hasattr(yesc_module, "parser")

--- a/yesc.py
+++ b/yesc.py
@@ -1690,6 +1690,7 @@ if __name__ == "__main__":
         sys.exit(0)
 '''
 # debug - commentout above and uncomment below
-args = parser.parse_args()
-main(args)
+if __name__ == "__main__":
+    args = parser.parse_args()
+    main(args)
 


### PR DESCRIPTION
## Summary

- Wrap `args = parser.parse_args()` and `main(args)` (lines 1693-1694) in an
  `if __name__ == "__main__":` guard so that `import yesc` no longer triggers
  argument parsing and execution

## Problem

The debug lines at the end of `yesc.py` sit at module level (outside the
`if __name__` guard), which means any `import yesc` immediately calls
`parser.parse_args()` and `main(args)`. This prevents using yesc as a library
— for example, building args programmatically and calling `main(args)` from
another script.

The commented-out try/except block (lines 1682-1691) was the original
implementation inside the guard. The current lines were placed at module level
for debugging and left in place.

## Change

Add `if __name__ == "__main__":` guard around lines 1693-1694 and indent them.
The `'''` string literal on line 1691 exits the original `if __name__` block
(it's at column 0), so these lines need their own guard rather than indenting
into the existing one.

## Impact

- **CLI usage (`python yesc.py ...`):** No change — `__name__` is `"__main__"`,
  guard fires as before
- **PyInstaller executable (`yesc.exe`):** No change — same reason
- **Library import (`from yesc import main`):** Now works without side effects